### PR TITLE
Replace inline SVG icons

### DIFF
--- a/assets/css/advantages.css
+++ b/assets/css/advantages.css
@@ -64,6 +64,12 @@
   stroke-linejoin: round;
 }
 
+.advantage-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .advantage-title {
   font-family: 'Philosopher', serif;
   color: var(--poison-green);

--- a/assets/css/solutions.css
+++ b/assets/css/solutions.css
@@ -84,6 +84,12 @@
   stroke-width: 2;
 }
 
+.solution-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .solution-title {
   font-family: 'Philosopher', serif;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -128,21 +128,7 @@
                 <!-- Карточка 1 - Наши технологии -->
                 <div class="solution-card">
                     <div class="solution-icon">
-                        <svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-gear">
-                            <circle cx="40" cy="40" r="20" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M40 20V15M40 65V60M60 40H65M15 40H20M54.14 25.86L57.07 22.93M22.93 57.07L25.86 54.14M54.14 54.14L57.07 57.07M22.93 22.93L25.86 25.86" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M40 30C34.48 30 30 34.48 30 40C30 45.52 34.48 50 40 50C45.52 50 50 45.52 50 40C50 34.48 45.52 30 40 30Z" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M40 10L43 15H37L40 10Z" fill="#00BA00"/>
-                            <path d="M40 70L43 65H37L40 70Z" fill="#00BA00"/>
-                            <path d="M10 40L15 43V37L10 40Z" fill="#00BA00"/>
-                            <path d="M70 40L65 43V37L70 40Z" fill="#00BA00"/>
-                            <path d="M18.93 18.93L24.14 21.86L20.86 25.14L18.93 18.93Z" fill="#00BA00"/>
-                            <path d="M61.07 61.07L55.86 58.14L59.14 54.86L61.07 61.07Z" fill="#00BA00"/>
-                            <path d="M18.93 61.07L21.86 55.86L25.14 59.14L18.93 61.07Z" fill="#00BA00"/>
-                            <path d="M61.07 18.93L58.14 24.14L54.86 20.86L61.07 18.93Z" fill="#00BA00"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-technologies.svg" alt="Технологии">
                     </div>
                     <h3 class="solution-title">Наши технологии</h3>
                     <p class="solution-text">QEngineering занимается разработкой передовых технологий обогащения и переработки полезных ископаемых.</p>
@@ -157,18 +143,7 @@
                 <!-- Карточка 2 - Цифровизация -->
                 <div class="solution-card">
                     <div class="solution-icon">
-                        <svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-vr">
-                            <path d="M15 30H65V50H15V30Z" fill="none" stroke="#00BA00" stroke-width="2" rx="5" ry="5"/>
-                            <path d="M15 40H65" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M40 30V50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M20 50C20 55 25 60 30 60C35 60 40 55 40 50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M60 50C60 55 55 60 50 60C45 60 40 55 40 50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M25 40C27.7614 40 30 37.7614 30 35C30 32.2386 27.7614 30 25 30" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M55 40C52.2386 40 50 37.7614 50 35C50 32.2386 52.2386 30 55 30" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M15 30H65V50H15V30Z" fill="#00BA00" fill-opacity="0.1"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-vr.svg" alt="Цифровизация">
                     </div>
                     <h3 class="solution-title">Цифровизация</h3>
                     <p class="solution-text">Мы используем VR/AR, цифровые двойники, автоматизацию — вы можете наблюдать за предприятием из любой точки мира.</p>
@@ -192,14 +167,7 @@
                 <!-- Карточка 1 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-profitable">
-                            <path d="M30 10L50 20V40L30 50L10 40V20L30 10Z" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 10V30M30 30L50 20M30 30L10 20" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 10L50 20V40L30 50L10 40V20L30 10Z" fill="#00BA00" fill-opacity="0.1"/>
-                            <path d="M25 35L35 25M25 25L35 35" fill="none" stroke="#00BA00" stroke-width="2"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-profitable.svg" alt="Выгодные решения">
                     </div>
                     <h3 class="advantage-title">ВЫГОДНЫЕ РЕШЕНИЯ</h3>
                     <p class="advantage-text">Подбираем проектные решения, которые экономят ресурсы и приносят максимум результата.</p>
@@ -208,14 +176,7 @@
                 <!-- Карточка 2 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-specialists">
-                            <circle cx="30" cy="20" r="10" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M15 50C15 42.268 21.268 36 29 36H31C38.732 36 45 42.268 45 50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 20m-10 0a10 10 0 1 0 20 0a10 10 0 1 0 -20 0" fill="#00BA00" fill-opacity="0.1"/>
-                            <path d="M30 25L30 15M25 20L35 20" fill="none" stroke="#00BA00" stroke-width="2"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-specialists.svg" alt="Лучшие специалисты">
                     </div>
                     <h3 class="advantage-title">ЛУЧШИЕ СПЕЦИАЛИСТЫ</h3>
                     <p class="advantage-text">В нашей команде — опытные инженеры и эксперты с реальным опытом работы в отрасли.</p>
@@ -224,14 +185,7 @@
                 <!-- Карточка 3 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-technologies">
-                            <path d="M15 45L15 15L45 15L45 45L15 45Z" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M20 25L25 30L20 35M30 25L35 30L30 35" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M15 35L45 35" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M15 15L45 15L45 45L15 45L15 15Z" fill="#00BA00" fill-opacity="0.1"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-technologies.svg" alt="Передовые технологии">
                     </div>
                     <h3 class="advantage-title">ПЕРЕДОВЫЕ ТЕХНОЛОГИИ</h3>
                     <p class="advantage-text">Внедряем современные цифровые инструменты и инженерные решения.</p>
@@ -240,15 +194,7 @@
                 <!-- Карточка 4 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-flexibility">
-                            <path d="M30 10C18.954 10 10 18.954 10 30C10 41.046 18.954 50 30 50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 50C41.046 50 50 41.046 50 30C50 18.954 41.046 10 30 10" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 20C24.477 20 20 24.477 20 30C20 35.523 24.477 40 30 40" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 40C35.523 40 40 35.523 40 30C40 24.477 35.523 20 30 20" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 10C18.954 10 10 18.954 10 30C10 41.046 18.954 50 30 50C41.046 50 50 41.046 50 30C50 18.954 41.046 10 30 10Z" fill="#00BA00" fill-opacity="0.1"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-flexibility.svg" alt="Гибкость">
                     </div>
                     <h3 class="advantage-title">ГИБКОСТЬ</h3>
                     <p class="advantage-text">Подстраиваемся под специфику каждого проекта — от задач до сроков.</p>
@@ -257,14 +203,7 @@
                 <!-- Карточка 5 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-speed">
-                            <circle cx="30" cy="30" r="20" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 20V30L38 38" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 10V15M30 45V50M10 30H15M45 30H50M16.36 16.36L19.9 19.9M40.1 40.1L43.64 43.64M16.36 43.64L19.9 40.1M40.1 19.9L43.64 16.36" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M30 30m-20 0a20 20 0 1 0 40 0a20 20 0 1 0 -40 0" fill="#00BA00" fill-opacity="0.1"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-speed.svg" alt="Скорость">
                     </div>
                     <h3 class="advantage-title">СКОРОСТЬ</h3>
                     <p class="advantage-text">Работаем слаженно и оперативно — сложные этапы выполняем в сжатые сроки.</p>
@@ -273,17 +212,7 @@
                 <!-- Карточка 6 -->
                 <div class="advantage-card">
                     <div class="advantage-icon">
-                        <svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
-                          <g id="icon-versatility">
-                            <path d="M10 15H50V45H10V15Z" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M20 15V45" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M40 15V45" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M10 25H50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M10 35H50" fill="none" stroke="#00BA00" stroke-width="2"/>
-                            <path d="M10 15H50V45H10V15Z" fill="#00BA00" fill-opacity="0.1"/>
-                            <circle cx="30" cy="30" r="5" fill="none" stroke="#00BA00" stroke-width="2"/>
-                          </g>
-                        </svg>
+                        <img src="assets/images/icons/icon-versatility.svg" alt="Универсальность">
                     </div>
                     <h3 class="advantage-title">УНИВЕРСАЛЬНОСТЬ</h3>
                     <p class="advantage-text">Присоединяемся к проекту на любом этапе и берём на себя всё необходимое.</p>


### PR DESCRIPTION
## Summary
- swap inline SVG icons for external SVG images in the solutions and advantages blocks
- handle `<img>` sizing in CSS

## Testing
- `git diff --name-only --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852917c4944832c9633acba81306cec