### PR TITLE
Remove duplicate footer logo styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -895,14 +895,6 @@ p {
   filter: drop-shadow(0 0 5px var(--poison-green-40));
 }
 
-.footer-logo .logo-text {
-  font-family: 'Futura PT', sans-serif;
-  font-weight: 400;
-  font-size: 11px;
-  line-height: 16px;
-  color: rgba(0, 0, 0, 0.898);
-  font-style: normal;
-}
 
 .footer-text {
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- drop the footer-specific `.logo-text` rule

## Testing
- `grep -n \.logo-text -n assets/css/styles.css`

------
https://chatgpt.com/codex/tasks/task_e_68616db62438832c9869da09331775ef