### PR TITLE
Remove redundant font declarations

### DIFF
--- a/assets/css/advantages.css
+++ b/assets/css/advantages.css
@@ -71,7 +71,6 @@
 }
 
 .advantage-title {
-  font-family: 'Futura PT', sans-serif;
   color: var(--poison-green);
   font-size: 1.2rem;
   margin-bottom: 15px;

--- a/assets/css/solutions.css
+++ b/assets/css/solutions.css
@@ -7,7 +7,6 @@
 .solutions-title {
   text-align: center;
   margin-bottom: 50px;
-  font-family: 'Futura PT', sans-serif;
   font-weight: 700;
   font-size: 2.5rem;
   color: #222;
@@ -91,7 +90,6 @@
 }
 
 .solution-title {
-  font-family: 'Futura PT', sans-serif;
   font-weight: 700;
   font-size: 1.5rem;
   color: #222;


### PR DESCRIPTION
## Summary
- rely on global `h1`-`h6` rule for advantage and solution titles
- clean up `advantages.css` and `solutions.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68616dc46f98832cb7595b12804a83c7