### PR TITLE
Add hover animation to 'Подробнее' buttons

### DIFF
--- a/assets/css/solutions.css
+++ b/assets/css/solutions.css
@@ -129,6 +129,8 @@
 .solution-btn:hover {
   background-color: #00BA00;
   color: #fff;
+  transform: scale(1.05);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
 }
 
 .solution-btn:hover svg {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -517,9 +517,12 @@ p {
   transition: transform var(--transition-fast);
 }
 
+
 .service-btn:hover {
   background-color: var(--poison-green);
   color: #fff;
+  transform: scale(1.05);
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
 }
 
 .service-btn:hover svg {


### PR DESCRIPTION
## Summary
- scale `service-btn` and `solution-btn` on hover
- add subtle box-shadow to hovered buttons
- keep arrow shift for "Подробнее" buttons

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68619951fd14832cb3e1c8e655d096cc