### PR TITLE
Fix duplicate hover styles

### DIFF
--- a/assets/css/solutions.css
+++ b/assets/css/solutions.css
@@ -126,12 +126,7 @@
   transition: transform 0.3s ease;
 }
 
-.solution-btn:hover {
-  background-color: #00BA00;
-  color: #fff;
-  transform: scale(1.05);
-  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
-}
+
 
 .solution-btn:hover svg {
   transform: translateX(5px);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -518,9 +518,10 @@ p {
 }
 
 
-.service-btn:hover {
+.service-btn:hover,
+.solution-btn:hover {
   background-color: var(--poison-green);
-  color: #fff;
+  color: var(--light-bg);
   transform: scale(1.05);
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## Summary
- remove redundant `.solution-btn:hover` styles from solutions.css
- combine `.service-btn:hover` and `.solution-btn:hover` into one rule in styles.css
- use `var(--light-bg)` for color instead of hardcoded `#fff`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861a376a0e0832c8e18fd97dc23e4b3