### PR TITLE
Add neon glare effect for service cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1401,3 +1401,29 @@ p {
   color: var(--light-bg);
   box-shadow: var(--neon-glow);
 }
+
+/* Neon Glare Hover Effect */
+.neon-glare-effect {
+  position: relative;
+  overflow: hidden;
+}
+
+.neon-glare-effect::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  transform: translateX(-100%);
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(100deg, 
+    rgba(0, 186, 0, 0) 20%, 
+    rgba(0, 186, 0, 0.4) 50%, 
+    rgba(0, 186, 0, 0) 80%
+  );
+  transition: transform 0.7s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  pointer-events: none;
+}
+
+.neon-glare-effect:hover::before {
+  transform: translateX(100%);
+}

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
             <h2>Направления деятельности</h2>
             
             <div class="services-grid">
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-mountain"></i>
                     </div>
@@ -95,7 +95,7 @@
                     </a>
                 </div>
                 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-hard-hat"></i>
                     </div>
@@ -108,7 +108,7 @@
                     </a>
                 </div>
                 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-industry"></i>
                     </div>
@@ -121,7 +121,7 @@
                     </a>
                 </div>
                 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-robot"></i>
                     </div>
@@ -134,7 +134,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-search"></i>
                     </div>
@@ -147,7 +147,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-file-signature"></i>
                     </div>
@@ -160,7 +160,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-drafting-compass"></i>
                     </div>
@@ -173,7 +173,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-leaf"></i>
                     </div>
@@ -186,7 +186,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-microchip"></i>
                     </div>
@@ -199,7 +199,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-tasks"></i>
                     </div>
@@ -212,7 +212,7 @@
                     </a>
                 </div>
 
-                <div class="service-card">
+                <div class="service-card neon-glare-effect">
                     <div class="service-icon">
                         <i class="fas fa-rocket"></i>
                     </div>


### PR DESCRIPTION
## Summary
- add `neon-glare-effect` CSS rule with hover animation
- apply `neon-glare-effect` class to all `.service-card` elements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686527bf3660832cbeeea4b128cf784c