### PR TITLE
Fix neon glare gradient color

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1415,9 +1415,9 @@ p {
   transform: translateX(-100%);
   width: 100%;
   height: 100%;
-  background: linear-gradient(100deg, 
-    transparent 20%, 
-    rgba(0, 186, 0, 0.4) 50%, 
+  background: linear-gradient(100deg,
+    transparent 20%,
+    var(--poison-green-40) 50%,
     transparent 80%
   );
   transition: transform 0.7s cubic-bezier(0.25, 0.46, 0.45, 0.94);


### PR DESCRIPTION
## Summary
- replace hard-coded rgba color in `.neon-glare-effect::after` with the CSS variable `var(--poison-green-40)`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686537bf5f20832cad829291c1ff3f43