### PR TITLE
Fix CTA icon width and logo text size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -209,7 +209,7 @@ p {
 
 /* Increase logo text size and weight in the header */
 .header .logo-text {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 700;
 }
 
@@ -1398,7 +1398,7 @@ p {
 
 .cta-button .cta-icon {
   height: 60px;
-  width: 60px;
+  width: auto;
   margin-right: 15px;
 }
 


### PR DESCRIPTION
## Summary
- prevent CTA button icon distortion by using automatic width
- use rem units for header logo text size for better accessibility

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68654d3310a0832cbbfe297a5ada9672