### PR TITLE
Add dark/light theme switcher

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -33,6 +33,25 @@
   --transition-medium: all 0.5s ease;
   --transition-slow: all 0.8s ease;
 }
+/* Dark Theme Variables */
+html.dark-mode {
+  --light-bg: #121212;
+  --light-gray-bg: #1E1E1E;
+  --medium-light-gray: #333333;
+  --light-text: #E0E0E0;
+  --medium-text: #A0A0A0;
+
+  --neon-glow: 0 0 10px var(--poison-green-60), 0 0 20px var(--poison-green-40);
+}
+
+html.dark-mode .service-card {
+    border-color: rgba(0, 186, 0, 0.4);
+}
+
+html.dark-mode .hero::before {
+    background: linear-gradient(135deg, rgba(0, 55, 2, 0.6), rgba(18, 18, 18, 0.8));
+}
+
 
 /* Сброс стилей */
 * {
@@ -1451,3 +1470,41 @@ p {
   filter: blur(0);
   transform: scale(1);
 }
+
+/* Theme Switcher Button */
+.theme-btn {
+    background: transparent;
+    border: 2px solid var(--poison-green-40);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: var(--medium-text);
+    transition: var(--transition-fast);
+    margin-right: 20px;
+}
+
+.theme-btn:hover {
+    color: var(--poison-green);
+    border-color: var(--poison-green);
+}
+
+.theme-btn .sun-icon {
+    display: none; /* Hidden by default */
+}
+.theme-btn .moon-icon {
+    display: block; /* Shown by default */
+}
+
+/* Icon display for dark mode */
+html.dark-mode .theme-btn .sun-icon {
+    display: block;
+}
+html.dark-mode .theme-btn .moon-icon {
+    display: none;
+}
+

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const themeSwitcher = document.getElementById('theme-switcher');
+    const htmlElement = document.documentElement; // Get the <html> element
+
+    // Function to apply the theme based on localStorage
+    const applyTheme = () => {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark') {
+            htmlElement.classList.add('dark-mode');
+        } else {
+            htmlElement.classList.remove('dark-mode');
+        }
+    };
+
+    // Apply theme on initial load to avoid flash of wrong theme
+    applyTheme();
+
+    // Event listener for the button click
+    themeSwitcher.addEventListener('click', () => {
+        htmlElement.classList.toggle('dark-mode');
+        
+        // Save the new theme preference to localStorage
+        if (htmlElement.classList.contains('dark-mode')) {
+            localStorage.setItem('theme', 'dark');
+        } else {
+            localStorage.setItem('theme', 'light');
+        }
+    });
+});

--- a/index.html
+++ b/index.html
@@ -40,6 +40,11 @@
                 </ul>
 
                 <a href="#contacts" class="btn desktop-contact-btn">Связаться</a>
+                <!-- Theme Switcher -->
+                <button id="theme-switcher" class="theme-btn" aria-label="Переключить тему">
+                    <i class="fas fa-moon moon-icon"></i>
+                    <i class="fas fa-sun sun-icon"></i>
+                </button>
 
                 <div class="lang-switch">
                     <button class="lang-btn active">RU</button>
@@ -535,6 +540,7 @@
     <script src="assets/js/solutions.js"></script>
     <script src="assets/js/partners.js"></script>
     <script src="assets/js/animations.js"></script>
+    <script src="assets/js/theme.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add theme switcher button to header
- support dark mode variables and button styles
- provide theme toggle logic in new script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869491aa03c832c8e14262a457a0abe